### PR TITLE
Fixes and refactoring

### DIFF
--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -397,7 +397,7 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 			cursorPosition = selectionBegin;
 			selecting = false;
 			
-		} else {
+		} else if (this->multiline) {
 			if (cursorPosition>0) {
 				int xx, yy;
 				getCursorCoords(cursorPosition, xx, yy);
@@ -419,7 +419,7 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		if(selecting) {
 			cursorPosition = selectionEnd;
 			selecting = false;
-		} else {
+		} else if (this->multiline) {
 			int xx, yy;
 			getCursorCoords(cursorPosition, xx, yy);
 			vector<string> lines = ofSplitString(text, "\n");

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -144,16 +144,6 @@ bool ofxTextInputField::getUseListeners() const {
 void ofxTextInputField::draw() {
 	ofPushMatrix();
 	ofTranslate(bounds.x, bounds.y);
-	
-	//debug graphics
-	ofPushStyle();
-	ofSetColor(255, 0, 0);
-	this->isEnabled() ? ofFill() : ofNoFill();
-	ofCircle(10, 10, 5);
-	ofSetColor(0, 255, 0);
-	this->isEditing() ? ofFill() : ofNoFill();
-	ofCircle(20, 10, 5);
-	ofPopStyle();
 
 	if(selecting) {
 		ofPushStyle();

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -1,22 +1,14 @@
 //
 //  textInput.cpp
 //
-//  Created by Elliot Woods on 09/12/2011.
-//  Copyright 2011 Kimchi and Chips.
-//
-//  modified by James George 12/2/2011
-//  modified by Momo the Monster 7/10/2012
-//  swappable fonts added by James George 9/11/2012
-//
 //	MIT license
 //	http://www.opensource.org/licenses/mit-license.php
 //
 
 #include "ofxTextInputField.h"
 
-
+//----------
 ofxTextInputField::ofxTextInputField() {
-    
     shiftMap[44] = '<';
     shiftMap[45] = '_';
     shiftMap[46] = '>';
@@ -45,7 +37,6 @@ ofxTextInputField::ofxTextInputField() {
 	selectionEnd = 0;
 	selecting = false;
 	
-	
 	fontRef = NULL;
     isEnabled = false;
 	isEditing = false;
@@ -56,13 +47,13 @@ ofxTextInputField::ofxTextInputField() {
 	mouseDownInRect = false;
 
 	fontRef = new ofxTextInput::BitmapFontRenderer();
-    //isSetup = false;
 	
-	VERTICAL_PADDING = 3;
-	HORIZONTAL_PADDING = 3;
+	verticalPadding = 3;
+	horizontalPadding = 3;
 	lastTimeCursorMoved = ofGetElapsedTimef();
 }
 
+//----------
 ofxTextInputField::~ofxTextInputField(){
 	if(isEnabled){
         disable();
@@ -70,11 +61,20 @@ ofxTextInputField::~ofxTextInputField(){
 
 }
 
+//----------
 void ofxTextInputField::setup(){
 	enable();
 }
 
+//----------
+void ofxTextInputField::setFont(OFX_TEXTFIELD_FONT_RENDERER& font){
+	if (fontRef->isBitmapFont()) {
+		delete fontRef;
+	}
+	fontRef = new ofxTextInput::TypedFontRenderer(&font);
+}
 
+//----------
 void ofxTextInputField::enable(){
 	if(!isEnabled){
 		ofAddListener(ofEvents().mousePressed, this, &ofxTextInputField::mousePressed);
@@ -84,6 +84,7 @@ void ofxTextInputField::enable(){
 	}
 }
 
+//----------
 void ofxTextInputField::disable(){
 	if(isEditing){
 		endEditing();
@@ -96,6 +97,8 @@ void ofxTextInputField::disable(){
     }
 	
 }
+
+//----------
 void ofxTextInputField::beginEditing() {
     if(!isEditing){
         ofAddListener(ofEvents().keyPressed, this, &ofxTextInputField::keyPressed);
@@ -113,6 +116,7 @@ void ofxTextInputField::beginEditing() {
     }
 }
 
+//----------
 void ofxTextInputField::endEditing() {
     if(isEditing){
         ofRemoveListener(ofEvents().keyPressed, this, &ofxTextInputField::keyPressed);
@@ -123,21 +127,17 @@ void ofxTextInputField::endEditing() {
     }
 }
 
-void ofxTextInputField::setFont(OFX_TEXTFIELD_FONT_RENDERER& font){
-	if(fontRef->isBitmapFont()) {
-		delete fontRef;
-	}
-	fontRef = new ofxTextInput::TypedFontRenderer(&font);
-}
-
+//----------
 bool ofxTextInputField::getIsEditing(){
     return isEditing;
 }
 
+//----------
 bool ofxTextInputField::getIsEnabled(){
 	return isEnabled;
 }
 
+//----------
 void ofxTextInputField::draw() {
     
 	ofPushMatrix();
@@ -213,10 +213,10 @@ void ofxTextInputField::draw() {
 		int cursorX, cursorY;
         getCursorCoords(cursorPosition, cursorX, cursorY);
 	//	printf("Pos: %d    X: %d   Y: %d\n", cursorPosition, cursorX, cursorY);
-		int cursorPos = HORIZONTAL_PADDING + fontRef->stringWidth(lines[cursorY].substr(0,cursorX));
+		int cursorPos = horizontalPadding + fontRef->stringWidth(lines[cursorY].substr(0, cursorX));
         
         
-		int cursorTop = VERTICAL_PADDING + fontRef->getLineHeight()*cursorY;
+		int cursorTop = verticalPadding + fontRef->getLineHeight()*cursorY;
 		int cursorBottom = cursorTop + fontRef->getLineHeight();
 		
 		
@@ -229,13 +229,14 @@ void ofxTextInputField::draw() {
         ofPopStyle();
     }
 	
-	fontRef->drawString(text, HORIZONTAL_PADDING, fontRef->getLineHeight()+VERTICAL_PADDING);
+	fontRef->drawString(text, horizontalPadding, fontRef->getLineHeight() + verticalPadding);
 	
 	
 	
 	ofPopMatrix();
 }
 
+//----------
 void ofxTextInputField::getCursorCoords(int pos, int &cursorX, int &cursorY) {
 	vector<string> lines = ofSplitString(text, "\n");
 	
@@ -254,20 +255,11 @@ void ofxTextInputField::getCursorCoords(int pos, int &cursorX, int &cursorY) {
 
 }
 
-/*
-void ofxTextInputField::setCursorPositionFromXY() {
-	cursorPosition = cursorx;
-	vector<string> parts = ofSplitString(text, "\n");
-	for(int i = 0 ; i < cursory; i++) {
-		cursorPosition += parts[i].size() + i; // for carriage returns
-	}
-}
-
-*/
+//----------
 int ofxTextInputField::getCursorPositionFromMouse(int x, int y) {
 	int cursorX = 0;
 	int cursorY = 0;
-	float pos = y - bounds.y - VERTICAL_PADDING;
+	float pos = y - bounds.y - verticalPadding;
 	pos /= fontRef->getLineHeight();
 	int line = pos;
 	cursorY = line;
@@ -275,7 +267,7 @@ int ofxTextInputField::getCursorPositionFromMouse(int x, int y) {
 	vector<string> lines = ofSplitString(text, "\n");
 	if(cursorY>=lines.size()-1) cursorY = lines.size()-1;
 	if(lines.size()>0) {
-		cursorX = fontRef->getPosition(lines[cursorY], x - HORIZONTAL_PADDING - bounds.x);
+		cursorX = fontRef->getPosition(lines[cursorY], x - horizontalPadding - bounds.x);
 	}
 	int c = 0;
 	for(int i = 0; i < cursorY; i++) {
@@ -285,7 +277,7 @@ int ofxTextInputField::getCursorPositionFromMouse(int x, int y) {
 	return c;
 }
 
-
+//----------
 void ofxTextInputField::mousePressed(ofMouseEventArgs& args){
 	mouseDownInRect = bounds.inside(args.x, args.y);
 	if(mouseDownInRect) {
@@ -296,6 +288,7 @@ void ofxTextInputField::mousePressed(ofMouseEventArgs& args){
 }
 
 
+//----------
 void ofxTextInputField::mouseDragged(ofMouseEventArgs& args) {
 	if(bounds.inside(args.x, args.y)) {
 		int pos = getCursorPositionFromMouse(args.x, args.y);
@@ -310,8 +303,8 @@ void ofxTextInputField::mouseDragged(ofMouseEventArgs& args) {
 	}
 }
 
+//----------
 void ofxTextInputField::mouseReleased(ofMouseEventArgs& args){
-
     if(bounds.inside(args.x, args.y)) {
         if(!isEditing && mouseDownInRect){
 	        beginEditing();
@@ -322,17 +315,7 @@ void ofxTextInputField::mouseReleased(ofMouseEventArgs& args){
 	}
 }
 
-
-#ifdef OF_VERSION_MINOR
-#if OF_VERSION_MINOR>=8 || OF_VERSION_MAJOR>0
-#define USE_GLFW_CLIPBOARD
-
-#endif
-#endif
-
-
 #ifdef USE_GLFW_CLIPBOARD
-
 
 #if (_MSC_VER)
 #include <GLFW/glfw3.h>
@@ -340,14 +323,13 @@ void ofxTextInputField::mouseReleased(ofMouseEventArgs& args){
 #include "GLFW/glfw3.h"
 #endif
 
-
-void ofxTextInputField::setClipboard(string clippy)
-{
+//----------
+void ofxTextInputField::setClipboard(string clippy){
 	glfwSetClipboardString( (GLFWwindow*) ofGetWindowPtr()->getCocoaWindow(), clippy.c_str());
 }
 
-string ofxTextInputField::getClipboard()
-{
+//----------
+string ofxTextInputField::getClipboard(){
 	const char *clip = glfwGetClipboardString((GLFWwindow*) ofGetWindowPtr()->getCocoaWindow());
 	if(clip!=NULL) {
 		return string(clip);
@@ -359,12 +341,12 @@ string ofxTextInputField::getClipboard()
 
 #endif
 
+//----------
 void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 	//ew: add charachter (non unicode sorry!)
 	//jg: made a step closer to this with swappable renderers and ofxFTGL -- but need unicode text input...
 	lastTimeCursorMoved = ofGetElapsedTimef();
 	int key = args.key;
-	
 	
     if(key == OF_KEY_SHIFT) {
         isShifted = true;
@@ -396,7 +378,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		}
 	}
 			
-			
 	if (key == OF_KEY_RETURN) {
 		if(!multiline) {
 			endEditing();
@@ -404,7 +385,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		}
 		text.insert(text.begin()+cursorPosition, '\n');
 		cursorPosition++;
-		
 
 		if(autoTab) {
 			// how much whitespace is there on the previous line?
@@ -459,7 +439,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		cursorPosition++;
 	}
 	
-	
 	if (key==OF_KEY_BACKSPACE) {
 		if(selecting) {
 			text.erase(text.begin() + selectionBegin,
@@ -501,8 +480,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		}
 	}
 	
-	
-	
 	if (key==OF_KEY_RIGHT){
 		if(selecting) {
 			cursorPosition = selectionEnd;
@@ -513,7 +490,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 			}
 		}
 	}
-	
 	
 	if (key==OF_KEY_UP){
 		if(selecting) {
@@ -538,8 +514,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		}
 	}
 	
-	
-	
 	if (key==OF_KEY_DOWN){
 		if(selecting) {
 			cursorPosition = selectionEnd;
@@ -560,12 +534,9 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 			}
 		}
 	}
-	
-	
-	
-	
 }
 
+//----------
 void ofxTextInputField::keyReleased(ofKeyEventArgs &a)
 {
     
@@ -578,6 +549,7 @@ void ofxTextInputField::keyReleased(ofKeyEventArgs &a)
     }
 }
 
+//----------
 void ofxTextInputField::clear() {
 	text.clear();
 	cursorPosition = 0;

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -109,7 +109,7 @@ void ofxTextInputField::beginEditing() {
         ofAddListener(ofEvents().keyPressed, this, &ofxTextInputField::keyPressed);
         ofAddListener(ofEvents().keyReleased, this, &ofxTextInputField::keyReleased);
         ofSendMessage(TEXTFIELD_IS_ACTIVE);
-        this->enabled = true;
+        this->editing = true;
         drawCursor = true;
 		if(autoClear) {
 			clear();
@@ -138,6 +138,16 @@ void ofxTextInputField::draw() {
 	ofPushMatrix();
 	ofTranslate(bounds.x, bounds.y);
 	
+	//debug graphics
+	ofPushStyle();
+	ofSetColor(255, 0, 0);
+	this->isEnabled() ? ofFill() : ofNoFill();
+	ofCircle(10, 10, 5);
+	ofSetColor(0, 255, 0);
+	this->isEditing() ? ofFill() : ofNoFill();
+	ofCircle(20, 10, 5);
+	ofPopStyle();
+
 	if(selecting) {
 		ofPushStyle();
 		// argh, splitting all the time.
@@ -272,7 +282,6 @@ void ofxTextInputField::mouseDragged(ofMouseEventArgs& args) {
 			selecting = true;
 			selectionBegin = MIN(pos, cursorPosition);
 			selectionEnd = MAX(pos, cursorPosition);
-			
 		} else {
 			selecting = false;
 		}
@@ -285,7 +294,7 @@ void ofxTextInputField::mouseReleased(ofMouseEventArgs& args) {
         if(!this->editing && mouseDownInRect) {
 	        beginEditing();
         }
-    } else if(this->editing){
+    } else {
 		endEditing();
 	}
 }
@@ -367,7 +376,6 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 			getCursorCoords(cursorPosition, xx, yy);
 			vector<string> lines = ofSplitString(text, "\n");
 			if(yy>0) {
-				
 				// collect all the whitespace on the previous line.
 				string previousWhitespace = "";
 				string previousLine = lines[yy-1];

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -255,7 +255,7 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 		this->commandHeld = true;
     }
 	
-    #ifdef USE_GLFW_CLIPBOARD
+#if defined(USE_GLFW_CLIPBOARD) && defined(TARGET_OSX)
     if(key == 'c' && this->commandHeld) {
         setClipboard(text.substr(selectionBegin, selectionEnd - selectionBegin));
         return;

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -113,7 +113,6 @@ void ofxTextInputField::beginEditing() {
 void ofxTextInputField::endEditing() {
     if(this->editing){
         ofSendMessage(TEXTFIELD_IS_INACTIVE);
-        ofNotifyEvent(textChanged, text, this);
         this->editing = false;
         this->drawCursor = false;
 		this->shiftHeld = false;
@@ -227,6 +226,7 @@ void ofxTextInputField::draw() {
 void ofxTextInputField::clear(){
 	text.clear();
 	cursorPosition = 0;
+	this->notifyTextChange();
 }
 
 //----------
@@ -269,12 +269,14 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 					   );
 			cursorPosition = selectionBegin;
 			selecting = false;
+			this->notifyTextChange();
 		}
 	}
 			
 	if (key == OF_KEY_RETURN) {
 		if(!multiline) {
 			endEditing();
+			this->notifyHitReturn();
 			return;
 		}
 		text.insert(text.begin()+cursorPosition, '\n');
@@ -310,7 +312,8 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 				cursorPosition += previousWhitespace.size();
 			}
 		}
-        return;
+		this->notifyTextChange();
+		return;
 	}
 	
 	if ((key >=32 && key <=126) || key=='\t') {
@@ -328,6 +331,7 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
             text.insert(text.begin()+cursorPosition, key);
         }
 		cursorPosition++;
+		this->notifyTextChange();
 	}
 	
 	if (key==OF_KEY_BACKSPACE) {
@@ -337,10 +341,13 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 			);
 			cursorPosition = selectionBegin;
 			selecting = false;
-		} else {
+			this->notifyTextChange();
+		}
+		else {
 			if (cursorPosition>0) {
 				text.erase(text.begin()+cursorPosition-1);
 				--cursorPosition;
+				this->notifyTextChange();
 			}
 		}
 	}
@@ -352,9 +359,12 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 					   );
 			cursorPosition = selectionBegin;
 			selecting = false;
-		} else {
+			this->notifyTextChange();
+		}
+		else {
 			if (text.size() > cursorPosition) {
 				text.erase(text.begin()+cursorPosition);
+				this->notifyTextChange();
 			}
 		}
 	}
@@ -519,6 +529,16 @@ string ofxTextInputField::getClipboard(){
 
 #endif
 
+
+//----------
+void ofxTextInputField::notifyTextChange() {
+	ofNotifyEvent(this->onTextChange, this->text, this);
+}
+
+//----------
+void ofxTextInputField::notifyHitReturn() {
+	ofNotifyEvent(this->onHitReturn, this->text, this);
+}
 
 //----------
 void ofxTextInputField::getCursorCoords(int pos, int &cursorX, int &cursorY) {

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -67,11 +67,16 @@ void ofxTextInputField::setup(bool enableListeners){
 }
 
 //----------
-void ofxTextInputField::setFont(OFX_TEXTFIELD_FONT_RENDERER& font){
+void ofxTextInputField::setFont(OFX_TEXTFIELD_FONT_RENDERER & font){
 	if (fontRef->isBitmapFont()) {
 		delete fontRef;
 	}
 	fontRef = new ofxTextInput::TypedFontRenderer(&font);
+}
+
+//----------
+ofxTextInput::FontRenderer * ofxTextInputField::getFontRenderer() {
+	return this->fontRef;
 }
 
 //----------
@@ -500,6 +505,16 @@ void ofxTextInputField::mouseReleased(ofMouseEventArgs& args) {
 	else {
 		endEditing();
 	}
+}
+
+//----------
+float ofxTextInputField::getVerticalPadding() const {
+	return this->verticalPadding;
+}
+
+//----------
+float ofxTextInputField::getHorizontalPadding() const {
+	return this->horizontalPadding;
 }
 
 #ifdef USE_GLFW_CLIPBOARD

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -38,8 +38,8 @@ ofxTextInputField::ofxTextInputField() {
 	selecting = false;
 	
 	fontRef = NULL;
-    isEnabled = false;
-	isEditing = false;
+    this->enabled = false;
+	this->editing = false;
     bounds = ofRectangle(0,0,100,22);
 	
     drawCursor = false;
@@ -55,7 +55,7 @@ ofxTextInputField::ofxTextInputField() {
 
 //----------
 ofxTextInputField::~ofxTextInputField(){
-	if(isEnabled){
+	if(this->enabled){
         disable();
     }
 
@@ -76,82 +76,69 @@ void ofxTextInputField::setFont(OFX_TEXTFIELD_FONT_RENDERER& font){
 
 //----------
 void ofxTextInputField::enable(){
-	if(!isEnabled){
+	if(!this->enabled){
 		ofAddListener(ofEvents().mousePressed, this, &ofxTextInputField::mousePressed);
 		ofAddListener(ofEvents().mouseDragged, this, &ofxTextInputField::mouseDragged);
 		ofAddListener(ofEvents().mouseReleased, this, &ofxTextInputField::mouseReleased);
-		isEnabled = true;
+		this->enabled = true;
 	}
 }
 
 //----------
 void ofxTextInputField::disable(){
-	if(isEditing){
+	if(this->editing){
 		endEditing();
 	}
-	if(isEnabled){
+	if(this->enabled){
         ofRemoveListener(ofEvents().mousePressed, this, &ofxTextInputField::mousePressed);
 		ofRemoveListener(ofEvents().mouseDragged, this, &ofxTextInputField::mouseDragged);
 		ofRemoveListener(ofEvents().mouseReleased, this, &ofxTextInputField::mouseReleased);
-		isEnabled = false;
+		this->enabled = false;
     }
 	
 }
 
 //----------
+bool ofxTextInputField::isEnabled() const {
+	return this->enabled;
+}
+
+//----------
 void ofxTextInputField::beginEditing() {
-    if(!isEditing){
+    if(!this->editing){
         ofAddListener(ofEvents().keyPressed, this, &ofxTextInputField::keyPressed);
         ofAddListener(ofEvents().keyReleased, this, &ofxTextInputField::keyReleased);
         ofSendMessage(TEXTFIELD_IS_ACTIVE);
-        isEditing = true;
+        this->enabled = true;
         drawCursor = true;
-		if(autoClear){
+		if(autoClear) {
 			clear();
-		}
-		else{
-
-
 		}
     }
 }
 
 //----------
 void ofxTextInputField::endEditing() {
-    if(isEditing){
+    if(this->editing){
         ofRemoveListener(ofEvents().keyPressed, this, &ofxTextInputField::keyPressed);
         ofSendMessage(TEXTFIELD_IS_INACTIVE);
         ofNotifyEvent(textChanged, text, this);
-        isEditing = false;
-        drawCursor = false;
+        this->editing = false;
+        this->drawCursor = false;
     }
 }
 
 //----------
-bool ofxTextInputField::getIsEditing(){
-    return isEditing;
-}
-
-//----------
-bool ofxTextInputField::getIsEnabled(){
-	return isEnabled;
+bool ofxTextInputField::isEditing() const {
+    return this->editing;
 }
 
 //----------
 void ofxTextInputField::draw() {
-    
 	ofPushMatrix();
 	ofTranslate(bounds.x, bounds.y);
-
-	
-	
-	
-
-
 	
 	if(selecting) {
-		
-
 		ofPushStyle();
 		// argh, splitting all the time.
 		vector<string> lines = ofSplitString(text, "\n");
@@ -168,26 +155,26 @@ void ofxTextInputField::draw() {
 		
 		if(beginCursorY==endCursorY) {
 			// single line selection
-			ofRect(HORIZONTAL_PADDING + startX, VERTICAL_PADDING + fontRef->getLineHeight()*beginCursorY,
+			ofRect(horizontalPadding + startX, verticalPadding + fontRef->getLineHeight()*beginCursorY,
 				   endX - startX, fontRef->getLineHeight());
 		} else {
 			
 			// multiline selection.
 			// do first line to the end
-			ofRect(HORIZONTAL_PADDING + startX, VERTICAL_PADDING + fontRef->getLineHeight()*beginCursorY,
+			ofRect(horizontalPadding + startX, verticalPadding + fontRef->getLineHeight()*beginCursorY,
 				   fontRef->stringWidth(lines[beginCursorY]) - startX,
 				   fontRef->getLineHeight()
 			);
 			
 			// loop through entirely selected lines
 			for(int i = beginCursorY + 1; i < endCursorY; i++) {
-				ofRect(HORIZONTAL_PADDING, VERTICAL_PADDING + fontRef->getLineHeight()*i,
+				ofRect(horizontalPadding, verticalPadding + fontRef->getLineHeight()*i,
 					   fontRef->stringWidth(lines[i]),
 					   fontRef->getLineHeight()
 				);
 			}
 			// do last line up to endX
-			ofRect(HORIZONTAL_PADDING, VERTICAL_PADDING + fontRef->getLineHeight()*endCursorY,
+			ofRect(horizontalPadding, verticalPadding + fontRef->getLineHeight()*endCursorY,
 					endX, fontRef->getLineHeight()
 			);
 		}
@@ -215,12 +202,8 @@ void ofxTextInputField::draw() {
 	//	printf("Pos: %d    X: %d   Y: %d\n", cursorPosition, cursorX, cursorY);
 		int cursorPos = horizontalPadding + fontRef->stringWidth(lines[cursorY].substr(0, cursorX));
         
-        
 		int cursorTop = verticalPadding + fontRef->getLineHeight()*cursorY;
 		int cursorBottom = cursorTop + fontRef->getLineHeight();
-		
-		
-		
 		
 		ofSetLineWidth(1.0f);
 		//TODO: multiline with fontRef
@@ -230,9 +213,6 @@ void ofxTextInputField::draw() {
     }
 	
 	fontRef->drawString(text, horizontalPadding, fontRef->getLineHeight() + verticalPadding);
-	
-	
-	
 	ofPopMatrix();
 }
 
@@ -240,10 +220,7 @@ void ofxTextInputField::draw() {
 void ofxTextInputField::getCursorCoords(int pos, int &cursorX, int &cursorY) {
 	vector<string> lines = ofSplitString(text, "\n");
 	
-	
 	int c = 0;
-	
-	
 	for(int i = 0; i < lines.size(); i++) {
 		if(pos<=c+lines[i].size()) {
 			cursorY = i;
@@ -252,7 +229,6 @@ void ofxTextInputField::getCursorCoords(int pos, int &cursorX, int &cursorY) {
 		}
 		c += lines[i].size() + 1;
 	}
-
 }
 
 //----------
@@ -278,7 +254,7 @@ int ofxTextInputField::getCursorPositionFromMouse(int x, int y) {
 }
 
 //----------
-void ofxTextInputField::mousePressed(ofMouseEventArgs& args){
+void ofxTextInputField::mousePressed(ofMouseEventArgs& args) {
 	mouseDownInRect = bounds.inside(args.x, args.y);
 	if(mouseDownInRect) {
 		cursorPosition = getCursorPositionFromMouse(args.x, args.y);
@@ -304,13 +280,12 @@ void ofxTextInputField::mouseDragged(ofMouseEventArgs& args) {
 }
 
 //----------
-void ofxTextInputField::mouseReleased(ofMouseEventArgs& args){
+void ofxTextInputField::mouseReleased(ofMouseEventArgs& args) {
     if(bounds.inside(args.x, args.y)) {
-        if(!isEditing && mouseDownInRect){
+        if(!this->editing && mouseDownInRect) {
 	        beginEditing();
         }
-    }
-    else if(isEditing){
+    } else if(this->editing){
 		endEditing();
 	}
 }
@@ -349,20 +324,20 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 	int key = args.key;
 	
     if(key == OF_KEY_SHIFT) {
-        isShifted = true;
+		this->shiftHeld = true;
     }
     
     if(key == 4352) {
-        isCommand = true;
+		this->commandHeld = true;
     }
 	
     #ifdef USE_GLFW_CLIPBOARD
-    if(key == 'c' && isCommand ) {
+    if(key == 'c' && this->commandHeld) {
         setClipboard(text.substr(selectionBegin, selectionEnd - selectionBegin));
         return;
     }
 	
-    if(key == 'v' && isCommand ) {
+	if(key == 'v' && this->commandHeld) {
         text.insert(cursorPosition, getClipboard());
         return;
     }
@@ -422,8 +397,7 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 	}
 	
 	if ((key >=32 && key <=126) || key=='\t') {
-        
-        if(isShifted) {
+        if(this->shiftHeld) {
             
             char toInsert;
             if( !(key > 96 && key < 123) && !(key > 65 && key < 90) && shiftMap.find(key) != shiftMap.end() ) {
@@ -537,20 +511,18 @@ void ofxTextInputField::keyPressed(ofKeyEventArgs& args) {
 }
 
 //----------
-void ofxTextInputField::keyReleased(ofKeyEventArgs &a)
-{
-    
+void ofxTextInputField::keyReleased(ofKeyEventArgs &a){
     if(a.key == 4352) {
-        isCommand = false;
+        this->commandHeld = false;
     }
 
     if(a.key == OF_KEY_SHIFT) {
-        isShifted = false;
+        this->shiftHeld = false;
     }
 }
 
 //----------
-void ofxTextInputField::clear() {
+void ofxTextInputField::clear(){
 	text.clear();
 	cursorPosition = 0;
 }

--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -517,6 +517,18 @@ float ofxTextInputField::getHorizontalPadding() const {
 	return this->horizontalPadding;
 }
 
+//----------
+void ofxTextInputField::setVerticalPadding(float vp){
+    verticalPadding = vp;
+}
+//----------
+void ofxTextInputField::setHorizontalPadding(float hp){
+    horizontalPadding = hp;
+}
+
+
+
+
 #ifdef USE_GLFW_CLIPBOARD
 
 #if (_MSC_VER)

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -46,7 +46,8 @@ class ofxTextInputField {
     void setup(bool enableListeners = true);
 
 	/// Change the font used to draw the text
-	void setFont(OFX_TEXTFIELD_FONT_RENDERER& font);
+	void setFont(OFX_TEXTFIELD_FONT_RENDERER & font);
+	ofxTextInput::FontRenderer * getFontRenderer();
 
 	void enable();
 	void disable();
@@ -91,6 +92,9 @@ class ofxTextInputField {
 	
 	bool multiline;
     
+	float getVerticalPadding() const;
+	float getHorizontalPadding() const;
+
 	#ifdef USE_GLFW_CLIPBOARD
     void setClipboard(string clippy);
     string getClipboard();

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -77,7 +77,9 @@ class ofxTextInputField {
 	int selectionEnd;
 	bool selecting;
 	
-	ofEvent<string> textChanged;
+	ofEvent<string> onTextChange;
+	ofEvent<string> onHitReturn;
+
 	void keyPressed(ofKeyEventArgs &a);
     void keyReleased(ofKeyEventArgs &a);
 	void mousePressed(ofMouseEventArgs& args);
@@ -108,6 +110,8 @@ class ofxTextInputField {
 
 	bool mouseDownInRect;
 	
+	void notifyTextChange();
+	void notifyHitReturn();
 	void getCursorCoords(int pos, int &cursorX, int &cursorY);
 	int getCursorPositionFromMouse(int x, int y);
     

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -43,7 +43,7 @@ class ofxTextInputField {
 	virtual ~ofxTextInputField();
 
 	/// Always call this first
-    void setup();
+    void setup(bool enableListeners = true);
 
 	/// Change the font used to draw the text
 	void setFont(OFX_TEXTFIELD_FONT_RENDERER& font);
@@ -52,21 +52,27 @@ class ofxTextInputField {
 	void disable();
     bool isEnabled() const;
 	
+	/// Whether the text box is focused and capturing keys
 	void beginEditing();
 	void endEditing();
 	bool isEditing() const;
 
+	void setUseListeners(bool);
+	bool getUseListeners() const;
+
+	/// Draw inside this->bounds
+	void draw();
+
+	/// Clear text
+	void clear();
+
     //can be set manually or otherwise is controlled by enable/disable
     bool drawCursor;
-    
-    ofRectangle bounds;
-	
-    void draw();
-	void clear();
 	
 	string text;
+
+	ofRectangle bounds;
 	int cursorPosition;
-	
 	int selectionBegin;
 	int selectionEnd;
 	bool selecting;
@@ -98,11 +104,17 @@ class ofxTextInputField {
 	
     bool enabled;
 	bool editing;
+	bool useListeners;
+
 	bool mouseDownInRect;
 	
 	void getCursorCoords(int pos, int &cursorX, int &cursorY);
 	int getCursorPositionFromMouse(int x, int y);
     
+	void addListeners();
+	void removeListeners();
+	bool hasListeners;
+
     bool shiftHeld, commandHeld;
     map<int, char> shiftMap;
 };

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -94,7 +94,10 @@ class ofxTextInputField {
     
 	float getVerticalPadding() const;
 	float getHorizontalPadding() const;
-
+    
+    void setVerticalPadding(float vp);
+    void setHorizontalPadding(float hp);
+    
 	#ifdef USE_GLFW_CLIPBOARD
     void setClipboard(string clippy);
     string getClipboard();

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -3,15 +3,16 @@
 //  textInput
 //
 //  Created by Elliot Woods on 09/12/2011.
-//  Copyright 2011 Kimchi and Chips.
-//
 //  modified by James George 12/2/2011
 //  modified by Momo the Monster 7/10/2012
 //  swappable fonts added by James George 9/11/2012
+//	refactoring and modifications by Elliot Woods on 30/11/2014
 //
 //	MIT license
 //	http://www.opensource.org/licenses/mit-license.php
 //
+
+// jg : TODO: text wrapping
 
 #pragma once
 
@@ -21,7 +22,7 @@
 //(like ofxFTGL or ofxFont)
 //to use ofxFTGL use somethinglike this:
 //#define OFX_TEXTFIELD_FONT_RENDERER ofxFTGLFont
-//#define OFX_TEXTFIELD_FONT_RENDERER "ofxFTGLFont.h"
+//#define OFX_TEXTFIELD_FONT_INCLUDE "ofxFTGLFont.h"
 
 #ifndef OFX_TEXTFIELD_FONT_RENDERER
 #define OFX_TEXTFIELD_FONT_RENDERER ofTrueTypeFont
@@ -34,19 +35,19 @@
 #define TEXTFIELD_IS_ACTIVE "textfieldIsActive"
 #define TEXTFIELD_IS_INACTIVE "textfieldIsInactive"
 
-
-// TODO: wrapping
 #include "ofxTextInputFieldFontRenderer.h"
 
 class ofxTextInputField {
   public:
 	ofxTextInputField();
 	virtual ~ofxTextInputField();
-	//swap in a font!
+
+	/// Always call this first
+    void setup(bool useEvents = trie);
+
+	/// Change the font used to draw the text
 	void setFont(OFX_TEXTFIELD_FONT_RENDERER& font);
-    
-    void setup();
-	
+
 	void enable();
 	void disable();
     bool getIsEnabled();
@@ -73,7 +74,10 @@ class ofxTextInputField {
 	ofEvent<string> textChanged;
 	void keyPressed(ofKeyEventArgs &a);
     void keyReleased(ofKeyEventArgs &a);
-	
+	void mousePressed(ofMouseEventArgs& args);
+	void mouseDragged(ofMouseEventArgs& args);
+	void mouseReleased(ofMouseEventArgs& args);
+
 	bool autoClear;
 	bool autoTab;
 	
@@ -93,9 +97,6 @@ class ofxTextInputField {
     bool 	isEnabled;
 	bool	isEditing;
 	bool	mouseDownInRect;
-	void    mousePressed(ofMouseEventArgs& args);
-    void    mouseDragged(ofMouseEventArgs& args);
-	void    mouseReleased(ofMouseEventArgs& args);
 	
 	
 	//int getLineForPosition(int pos);

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -98,7 +98,7 @@ class ofxTextInputField {
     void setVerticalPadding(float vp);
     void setHorizontalPadding(float hp);
     
-	#ifdef USE_GLFW_CLIPBOARD
+	#if defined(USE_GLFW_CLIPBOARD) && defined(TARGET_OSX)
     void setClipboard(string clippy);
     string getClipboard();
 	#endif

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -43,19 +43,19 @@ class ofxTextInputField {
 	virtual ~ofxTextInputField();
 
 	/// Always call this first
-    void setup(bool useEvents = trie);
+    void setup();
 
 	/// Change the font used to draw the text
 	void setFont(OFX_TEXTFIELD_FONT_RENDERER& font);
 
 	void enable();
 	void disable();
-    bool getIsEnabled();
+    bool isEnabled() const;
 	
-	bool getIsEditing();
 	void beginEditing();
 	void endEditing();
-	
+	bool isEditing() const;
+
     //can be set manually or otherwise is controlled by enable/disable
     bool drawCursor;
     
@@ -90,23 +90,19 @@ class ofxTextInputField {
 	
   protected:
 	float lastTimeCursorMoved;
-	int VERTICAL_PADDING;
-	int HORIZONTAL_PADDING;
+	
+	float verticalPadding;
+	float horizontalPadding;
+
 	ofxTextInput::FontRenderer* fontRef;
 	
-    bool 	isEnabled;
-	bool	isEditing;
-	bool	mouseDownInRect;
+    bool enabled;
+	bool editing;
+	bool mouseDownInRect;
 	
-	
-	//int getLineForPosition(int pos);
-
-	//void setCursorPositionFromXY();
-	//void setCursorFromMouse(int x, int y);
-	//void setCursorXYFromPosition();
 	void getCursorCoords(int pos, int &cursorX, int &cursorY);
 	int getCursorPositionFromMouse(int x, int y);
     
-    bool isShifted, isCommand;
+    bool shiftHeld, commandHeld;
     map<int, char> shiftMap;
 };


### PR DESCRIPTION
Especially clean up listener patterns and white space

I noticed a few things 'not working as expected', in which case i've been sure to change the names of the accessors. 

e.g. textChange event was being fired only when editing ended (this of course should be a seperate event if you want it).

I had to make changes to stop always using ofAddListener to global events, since in my case i'm not using global listeners. 

Tested with the example (had to make my own project file).

Still editing now but opening the PR to holler out
