### PR TITLE
Fix for misplaced define clause

### DIFF
--- a/src/ofxTextInputField.cpp
+++ b/src/ofxTextInputField.cpp
@@ -323,12 +323,7 @@ void ofxTextInputField::mouseReleased(ofMouseEventArgs& args){
 }
 
 
-#ifdef OF_VERSION_MINOR
-#if OF_VERSION_MINOR>=8 || OF_VERSION_MAJOR>0
-#define USE_GLFW_CLIPBOARD
 
-#endif
-#endif
 
 
 #ifdef USE_GLFW_CLIPBOARD

--- a/src/ofxTextInputField.h
+++ b/src/ofxTextInputField.h
@@ -34,7 +34,12 @@
 #define TEXTFIELD_IS_ACTIVE "textfieldIsActive"
 #define TEXTFIELD_IS_INACTIVE "textfieldIsInactive"
 
+#ifdef OF_VERSION_MINOR
+#if OF_VERSION_MINOR>=8 || OF_VERSION_MAJOR>0
+#define USE_GLFW_CLIPBOARD
 
+#endif
+#endif
 // TODO: wrapping
 #include "ofxTextInputFieldFontRenderer.h"
 


### PR DESCRIPTION
Having the #define USE_GLFW_CLIPBOARD in the cpp file causes out of line error when true as header definition wasn't defined.
